### PR TITLE
Configure GitHub Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "card-dungeon",
   "version": "1.0.0",
   "private": true,
+  "homepage": "https://hendrism.github.io/card-dungeon",
   "scripts": {
     "start": "vite",
     "build": "vite build",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: '/card-dungeon/',
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- specify GitHub Pages `homepage` URL in `package.json`
- add a `vite.config.js` configured for the repo

Make sure GitHub Pages is set to use the `gh-pages` branch after deploying.

## Testing
- `npm run deploy` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae8d2cee08320866889ad408ca691